### PR TITLE
sentinel: remove authentication for Redis 6.0.0 PHP extension

### DIFF
--- a/Transport/Connection.php
+++ b/Transport/Connection.php
@@ -111,10 +111,6 @@ class Connection
                         'readTimeout' => $options['read_timeout'],
                     ];
 
-                    if ($auth !== null) {
-                        $connectOptions['auth'] = $auth;
-                    }
-
                     $sentinelClient = new \RedisSentinel($connectOptions);
                 } else {
                     $sentinelClient = new \RedisSentinel($host, $port, $options['timeout'], $options['persistent_id'], $options['retry_interval'], $options['read_timeout']);


### PR DESCRIPTION
- for older extension version there was no authentication provided
- auth is used only for redis and redis cluster